### PR TITLE
[codex] Add build-time env probe for comment overrides

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,6 +2,7 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 ENV COREPACK_DEFAULT_TO_LATEST=0
+ARG COMMENT_ENV_PROBE=unset
 
 RUN corepack enable 
 
@@ -11,6 +12,9 @@ COPY package.json ./
 RUN pnpm install
 
 COPY . .
+
+# Bake a build-only marker into a static asset so PR comment env overrides are easy to verify.
+RUN printf '%s\n' "${COMMENT_ENV_PROBE}" > public/build-probe.txt
 
 RUN pnpm run build
 

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -36,6 +36,7 @@ services:
           ports:
             - 3000
           env:
+            COMMENT_ENV_PROBE: "default-build-value"
             COMPONENT: "app"
             ENV: "lifecycle"
             API_URL: "https://{{{backend_publicUrl}}}"


### PR DESCRIPTION
## What changed
Adds a minimal repro for Lifecycle PR comment environment overrides in the example frontend service.

- adds COMMENT_ENV_PROBE to frontend in lifecycle.yaml
- bakes that value into public/build-probe.txt during Dockerfile.frontend build

## Why
This makes it easy to test whether a PR comment override reaches the Docker build itself, not just the deployed runtime environment.

Expected test flow:
1. Deploy the PR environment and verify /build-probe.txt returns default-build-value.
2. Add a Lifecycle PR comment override: ENV:COMMENT_ENV_PROBE:comment-override-value.
3. Redeploy and verify /build-probe.txt again.

If the file still returns default-build-value, that indicates the image was rebuilt or retagged without passing the comment override into the image build inputs.

## Impact
This change is only for validating Lifecycle behavior in the example repo.

## Validation
- pnpm lint
- pnpm exec tsc --noEmit
- pnpm build