### PR TITLE
test: remote ignoreFiles pre-baseline

### DIFF
--- a/remote-env-ignore/pre-ignore-baseline.md
+++ b/remote-env-ignore/pre-ignore-baseline.md
@@ -1,0 +1,1 @@
+This file verifies that remote dependency pushes redeploy before ignoreFiles is configured.


### PR DESCRIPTION
E2E fixture commit for Lifecycle remote dependency ignoreFiles testing. This adds a file under a path that is not ignored yet, so existing remote dependency environments should redeploy before the policy is added.