### PR TITLE
test: add remote ignoreFiles fixture services

### DIFF
--- a/Dockerfile.remote-fixture
+++ b/Dockerfile.remote-fixture
@@ -1,0 +1,5 @@
+FROM busybox:1.36
+
+EXPOSE 8080
+
+CMD ["sh", "-c", "while true; do { printf 'HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok'; } | nc -l -p 8080; done"]

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -99,6 +99,40 @@ services:
         public: false
         readiness:
           tcpSocketPort: 6379
+  - name: "remote-fixture-a"
+    defaultUUID: "dev-0"
+    github:
+      repository: "vigneshrajsb/lifecycle-examples"
+      branchName: "main"
+      docker:
+        builder:
+          engine: "buildkit"
+        defaultTag: "main"
+        app:
+          dockerfilePath: "Dockerfile.remote-fixture"
+          ports:
+            - 8080
+      deployment:
+        public: false
+        readiness:
+          tcpSocketPort: 8080
+  - name: "remote-fixture-b"
+    defaultUUID: "dev-0"
+    github:
+      repository: "vigneshrajsb/lifecycle-examples"
+      branchName: "main"
+      docker:
+        builder:
+          engine: "buildkit"
+        defaultTag: "main"
+        app:
+          dockerfilePath: "Dockerfile.remote-fixture"
+          ports:
+            - 8080
+      deployment:
+        public: false
+        readiness:
+          tcpSocketPort: 8080
   - name: "jenkins"
     helm:
       repository: "vmelikyan/lc-test"


### PR DESCRIPTION
Adds two tiny GitHub-backed services used by backend-svc E2E PRs to verify Lifecycle remote dependency ignoreFiles behavior. No ignoreFiles policy is added in this step so we can test baseline redeploy behavior first.