### PR TITLE
test: tracked remote pre-ignore fixture

### DIFF
--- a/remote-env-ignore/pre-ignore-fixture.md
+++ b/remote-env-ignore/pre-ignore-fixture.md
@@ -1,0 +1,1 @@
+This file verifies tracked remote GitHub services redeploy before ignoreFiles is configured.


### PR DESCRIPTION
Adds a tracked remote dependency fixture file before ignoreFiles is configured. The backend-svc E2E environments should redeploy from the lifecycle-examples main push.