### PR TITLE
test: tracked remote pre-ignore default-branch file

### DIFF
--- a/remote-env-ignore/pre-ignore-tracked.md
+++ b/remote-env-ignore/pre-ignore-tracked.md
@@ -1,0 +1,1 @@
+This file verifies tracked default-branch remote services redeploy before ignoreFiles is configured.


### PR DESCRIPTION
Adds another remote-env-ignore file after enabling trackDefaultBranches in the local test DB. Because ignoreFiles is not configured yet, the backend-svc fixture builds should redeploy.