### PR TITLE
test: add remote ignoreFiles policy

### DIFF
--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -14,6 +14,8 @@
 
 environment:
   autoDeploy: true
+  ignoreFiles:
+    - "remote-env-ignore/**"
   defaultServices:
     - name: "frontend"
     - name: "backend"
@@ -100,6 +102,10 @@ services:
         readiness:
           tcpSocketPort: 6379
   - name: "remote-fixture-a"
+    ignoreFiles:
+      - "remote-fixture-a-ignore/**"
+      - "remote-fixture-shared-ignore/**"
+      - "remote-compare-ignore/**"
     defaultUUID: "dev-0"
     github:
       repository: "vigneshrajsb/lifecycle-examples"
@@ -117,6 +123,10 @@ services:
         readiness:
           tcpSocketPort: 8080
   - name: "remote-fixture-b"
+    ignoreFiles:
+      - "remote-fixture-b-ignore/**"
+      - "remote-fixture-shared-ignore/**"
+      - "remote-compare-ignore/**"
     defaultUUID: "dev-0"
     github:
       repository: "vigneshrajsb/lifecycle-examples"

--- a/remote-compare-ignore/remove-me.md
+++ b/remote-compare-ignore/remove-me.md
@@ -1,0 +1,1 @@
+This file will be deleted to force push payload compare fallback while still matching ignoreFiles.


### PR DESCRIPTION
Adds ignoreFiles policy for remote dependency E2E testing: environment-level path, fixture-a-only service path, shared service-level path, and a compare-fallback delete fixture.