### PR TITLE
test: env-level ignoreFiles skip fixture

### DIFF
--- a/remote-env-ignore/post-policy-env.md
+++ b/remote-env-ignore/post-policy-env.md
@@ -1,0 +1,1 @@
+Environment-level ignoreFiles skip fixture.


### PR DESCRIPTION
E2E fixture for Lifecycle ignoreFiles remote dependency testing. Adds a file covered only by environment.ignoreFiles.