### PR TITLE
test: fixture-a-only ignoreFiles case

### DIFF
--- a/remote-fixture-a-ignore/a-only.md
+++ b/remote-fixture-a-ignore/a-only.md
@@ -1,0 +1,1 @@
+Service-level ignoreFiles fixture for remote-fixture-a only.


### PR DESCRIPTION
E2E fixture for Lifecycle ignoreFiles remote dependency testing. Adds a file covered by remote-fixture-a ignoreFiles but not remote-fixture-b.