### PR TITLE
test: shared service ignoreFiles skip fixture

### DIFF
--- a/remote-fixture-shared-ignore/shared.md
+++ b/remote-fixture-shared-ignore/shared.md
@@ -1,0 +1,1 @@
+Shared service-level ignoreFiles fixture.


### PR DESCRIPTION
E2E fixture for Lifecycle ignoreFiles remote dependency testing. Adds a file covered by both remote fixture service ignoreFiles policies.