### PR TITLE
test: deleted ignored file compare fallback

### DIFF
--- a/remote-compare-ignore/remove-me.md
+++ b/remote-compare-ignore/remove-me.md
@@ -1,1 +1,0 @@
-This file will be deleted to force push payload compare fallback while still matching ignoreFiles.


### PR DESCRIPTION
E2E fixture for Lifecycle ignoreFiles remote dependency testing. Deletes an ignored file so push handling must use compare fallback.