### PR TITLE
test: lifecycle next15 smoke marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Here's the starter workflow:
 
 Once the pull request is created, Lifecycle will pick up the config(`lifecycle.yaml`) from your branch and attempt to provision an  environment based on its definitions. You can then test your setup in this isolated starter environment.
 asdas
+
+Smoke test marker for the Lifecycle Next 15 local upgrade validation.


### PR DESCRIPTION
Smoke PR for validating the local Lifecycle Next.js 15 upgrade path.\n\nLocal checks from /private/tmp/lifecycle-examples-next15-smoke:\n- pnpm install --frozen-lockfile\n- pnpm lint\n- pnpm build\n\nNote: local Lifecycle Tilt is running on kind-lfc and app health is passing, but this local instance currently has dummy GitHub App credentials from .env.ci, so it cannot authenticate GitHub App API actions until real local app credentials are installed.